### PR TITLE
Remove duplicate js and css loaded on discussion page

### DIFF
--- a/templates/original-permalink.php
+++ b/templates/original-permalink.php
@@ -27,7 +27,6 @@ wp_localize_script(
 );
 gp_enqueue_style( 'gp-discussion-css' );
 gp_tmpl_header();
-gp_head();
 
 ?>
 


### PR DESCRIPTION
The content of the files `translation-discussion.js` and `translation-discussion.css` are loaded twice when we view the page source of discussion page of a translation e.g http://localhost:8888/projects/wp/dev/2304/es/default/

In this PR, `gp_head()` is removed to stop the files again, since it's already called in the `gp_tmpl_header()` function already present on the page.