### PR TITLE
Add the related locales to Russian

### DIFF
--- a/helpers/helper-other-locales.php
+++ b/helpers/helper-other-locales.php
@@ -49,6 +49,7 @@ class Helper_Other_Locales extends GP_Translation_Helper {
 		'ne'  => array( 'hi', 'mr', 'as' ),
 		'oci' => array( 'ca', 'fr', 'it', 'es', 'gl' ),
 		'ug'  => array( 'tr', 'uz', 'az', 'zh-cn', 'zh-tw' ),
+		'ru'  => array( 'de', 'nl', 'es', 'sv', 'sr', 'bel', 'uk', 'cs', 'ro', 'it', 'pl', 'fr', 'ko', 'zh-cn', 'zh-tw', 'ja' ),
 	);
 
 	/**


### PR DESCRIPTION
## Problem

The plugin doesn't have the related locales to Russian.

Fixes https://github.com/GlotPress/gp-translation-helpers/issues/231.

Proposed by [Yui](https://profiles.wordpress.org/fierevere/) (@fierevere), who is a [Russian LM and GTE](https://make.wordpress.org/polyglots/teams/?locale=ru_RU).

<!--
Please describe what is the status/problem before the PR.
-->

## Solution

This PR adds an array with the related locales to Russian.

You can check it [here](https://translate.wordpress.org/projects/wp-plugins/woocommerce/dev/ru/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=571092&filters%5Btranslation_id%5D=82993768), and you can see the improvement in this screenshot.

<img width="3390" height="2322" alt="image" src="https://github.com/user-attachments/assets/19a0d832-e4d1-455a-8a57-c9db23cc9b87" />


<!--
Please describe how this PR improves the situation.
-->


