### PR TITLE
Fix PHP 8.2+ deprecation warnings

### DIFF
--- a/helpers/base-helper.php
+++ b/helpers/base-helper.php
@@ -24,6 +24,14 @@ class GP_Translation_Helper {
 	public $data;
 
 	/**
+	 * The number of items returned by the helper. Set by set_count().
+	 *
+	 * @since 0.0.1
+	 * @var int
+	 */
+	public $count;
+
+	/**
 	 * GP_Translation_Helper constructor.
 	 *
 	 * Will throw a LogicException if the title property is not set.

--- a/helpers/helper-translation-discussion.php
+++ b/helpers/helper-translation-discussion.php
@@ -878,7 +878,7 @@ function gth_print_translation( $comment_translation_id, $args, $prefix = '' ) {
 			<?php
 			echo esc_html( $prefix );
 			if ( $translation_permalink ) {
-				echo wp_kses( gp_link( $translation_permalink, $translation->translation_0 ), array( 'a' => array( 'href' => true ) ) );
+				gp_link( $translation_permalink, $translation->translation_0 );
 			} else {
 				echo esc_html( $translation->translation_0 );
 			}

--- a/helpers/helper-translation-history.php
+++ b/helpers/helper-translation-history.php
@@ -73,7 +73,7 @@ class Helper_History extends GP_Translation_Helper {
 			function ( $t1, $t2 ) {
 				$cmp_prop_t1 = $t1->date_modified ?? $t1->date_added;
 				$cmp_prop_t2 = $t2->date_modified ?? $t2->date_added;
-				return $cmp_prop_t1 < $cmp_prop_t2;
+				return $cmp_prop_t2 <=> $cmp_prop_t1;
 			}
 		);
 

--- a/includes/class-gth-temporary-post.php
+++ b/includes/class-gth-temporary-post.php
@@ -3,6 +3,7 @@
 class Gth_Temporary_Post {
 	public $ID;
 	public $comments_open = 'open';
+	public $filter;
 	public function __construct( $post_id ) {
 		$this->ID = $post_id;
 	}


### PR DESCRIPTION
## Summary

- **`Gth_Temporary_Post::$filter`** — core's `sanitize_post()` assigns `$post->filter = $context;` on any post-shaped object. Declare the property to silence the warning. (33 hits)
- **`GP_Translation_Helper::$count`** — `set_count()` / `get_count()` use this on every helper. The Discussion / History / Other-Locales subclasses each tripped the warning. Declared on the base class. (3 × 45 = 135 hits)
- **`usort` returning bool** in `helper-translation-history.php` — replaced `return \$a < \$b;` with `return \$b <=> \$a;`. PHP 8.0+ deprecates bool returns. As a side-benefit, the spaceship operator also correctly orders strictly-greater pairs that the bool form mapped to `0` (equal). Sort direction (newest first) is unchanged. (28 hits)
- **`wp_kses( gp_link(...) )`** in `helper-translation-discussion.php` print_translation — `gp_link()` *echoes* and returns null, so the original code was emitting the link from `gp_link()` and then `echo`-ing `wp_kses(null, ...)` which is an empty string. Replaced with a plain `gp_link()` call. (34 hits, plus a `preg_replace(): Passing null` chain inside KSES.)

## Test plan

- [ ] Open a translation discussion thread with at least one parent + child comment; confirm the linked-translation prefix still renders correctly inside `<em>` and the link is clickable.
- [ ] Open a translation's history; confirm rows are still ordered newest-first.
- [ ] Open a glossary translation pair (loads Other-Locales / History / Discussion helpers); confirm the count badges still appear.
- [ ] Tail PHP error log during the above and confirm none of the four deprecations recur.